### PR TITLE
change memory from 512->256

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,7 +20,7 @@ applications:
   name: portfolio-chat-newbot
   command: npm start
   path: .
-  memory: 512M
+  memory: 256M
   instances: 1
   domain: mybluemix.net
   disk_quota: 1024M


### PR DESCRIPTION
In anticipation of Bluemix's freemium changes, we should change the app memory from 512 to 256 (since 256 is in the free tier)