### PR TITLE
Add linting for travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ cache:
   directories:
     - node_modules
 script:
-  - npm test
+  - npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "resolved": "https://registry.npmjs.org/@ciscospark/common/-/common-0.7.87.tgz",
       "integrity": "sha1-coWiGjWMYsjOTMPZkDhdiA03D2Y=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "backoff": "2.5.0",
-        "core-decorators": "0.14.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10",
-        "urlsafe-base64": "1.0.0"
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "core-decorators": "^0.14.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4",
+        "urlsafe-base64": "^1.0.0"
       }
     },
     "@ciscospark/http-core": {
@@ -23,16 +23,16 @@
       "integrity": "sha1-2bjI4PGmdhB9t+zNhpY1NE3UIfg=",
       "requires": {
         "@ciscospark/common": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1",
-        "file-type": "3.9.0",
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "lodash": "4.17.10",
-        "parse-headers": "2.0.1",
-        "qs": "5.2.1",
-        "request": "2.87.0",
-        "xtend": "4.0.1"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1",
+        "file-type": "^3.9.0",
+        "global": "^4.3.1",
+        "is-function": "^1.0.1",
+        "lodash": "^4.17.4",
+        "parse-headers": "^2.0.1",
+        "qs": "^5.2.1",
+        "request": "^2.81.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "qs": {
@@ -49,8 +49,8 @@
       "requires": {
         "@ciscospark/plugin-wdm": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1"
       }
     },
     "@ciscospark/plugin-locus": {
@@ -60,9 +60,9 @@
       "requires": {
         "@ciscospark/plugin-mercury": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4"
       }
     },
     "@ciscospark/plugin-logger": {
@@ -72,9 +72,9 @@
       "requires": {
         "@ciscospark/common": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4"
       }
     },
     "@ciscospark/plugin-mercury": {
@@ -86,13 +86,13 @@
         "@ciscospark/plugin-feature": "0.7.87",
         "@ciscospark/plugin-wdm": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "backoff": "2.5.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10",
-        "string": "3.3.3",
-        "uuid": "3.3.2",
-        "ws": "1.1.5"
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4",
+        "string": "^3.3.3",
+        "uuid": "^3.0.1",
+        "ws": "^1.1.4"
       },
       "dependencies": {
         "uuid": {
@@ -110,8 +110,8 @@
         "@ciscospark/common": "0.7.87",
         "@ciscospark/plugin-wdm": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1"
       }
     },
     "@ciscospark/plugin-people": {
@@ -120,8 +120,8 @@
       "integrity": "sha1-CzxymKOSGtfWddy8ntAuT2Rowz4=",
       "requires": {
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1"
       }
     },
     "@ciscospark/plugin-phone": {
@@ -133,14 +133,14 @@
         "@ciscospark/plugin-locus": "0.7.87",
         "@ciscospark/plugin-metrics": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "ampersand-state": "5.0.3",
-        "babel-runtime": "6.26.0",
-        "detectrtc": "1.3.6",
-        "envify": "3.4.1",
-        "lodash": "4.17.10",
-        "sdp-transform": "2.4.1",
-        "uuid": "3.3.2",
-        "webrtc-adapter": "3.4.3"
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "detectrtc": "^1.3.4",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4",
+        "sdp-transform": "^2.3.0",
+        "uuid": "^3.0.1",
+        "webrtc-adapter": "^3.2.0"
       },
       "dependencies": {
         "uuid": {
@@ -158,11 +158,11 @@
         "@ciscospark/common": "0.7.87",
         "@ciscospark/http-core": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
-        "ampersand-collection": "2.0.2",
-        "ampersand-state": "5.0.3",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10"
+        "ampersand-collection": "^2.0.0",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4"
       }
     },
     "@ciscospark/spark-core": {
@@ -172,12 +172,12 @@
       "requires": {
         "@ciscospark/common": "0.7.87",
         "@ciscospark/http-core": "0.7.87",
-        "ampersand-events": "2.0.2",
-        "ampersand-state": "5.0.3",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10",
-        "uuid": "3.3.2"
+        "ampersand-events": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
         "uuid": {
@@ -193,8 +193,8 @@
       "integrity": "sha1-J4o5NLBp3XpFzZEDXf1uuBBSq9g=",
       "requires": {
         "@ciscospark/spark-core": "0.7.87",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1"
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1"
       }
     },
     "@types/async": {
@@ -207,8 +207,8 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "requires": {
-        "@types/connect": "3.4.32",
-        "@types/node": "9.6.24"
+        "@types/connect": "*",
+        "@types/node": "*"
       }
     },
     "@types/caseless": {
@@ -221,7 +221,7 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "requires": {
-        "@types/node": "9.6.24"
+        "@types/node": "*"
       }
     },
     "@types/csv-stringify": {
@@ -229,7 +229,7 @@
       "resolved": "https://registry.npmjs.org/@types/csv-stringify/-/csv-stringify-1.4.2.tgz",
       "integrity": "sha512-OxBpngVW09fD5S90Fi2ihWJa9gWk/cYSeZ05T5PiElOJw4OjKq9bXyVEkEPpHS/1Vr/gKzAgv7okuvHLpb5CSA==",
       "requires": {
-        "@types/node": "9.6.24"
+        "@types/node": "*"
       }
     },
     "@types/events": {
@@ -242,9 +242,9 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
       "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
       "requires": {
-        "@types/body-parser": "1.17.0",
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/serve-static": "1.13.2"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -252,9 +252,9 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
       "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "requires": {
-        "@types/events": "1.2.0",
-        "@types/node": "9.6.24",
-        "@types/range-parser": "1.2.2"
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/extend": {
@@ -267,7 +267,7 @@
       "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.1.tgz",
       "integrity": "sha512-Im0cJaIPJbbpuW91OrjXnqWPZCJK/tcFy2cFX+1qjG1gubgVZPPO9OVsTVAjotN4I1E6FAV0eIqt+rR8Y1c3iA==",
       "requires": {
-        "@types/node": "9.6.24"
+        "@types/node": "*"
       }
     },
     "@types/form-data": {
@@ -275,7 +275,7 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "9.6.24"
+        "@types/node": "*"
       }
     },
     "@types/is-stream": {
@@ -283,7 +283,7 @@
       "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "requires": {
-        "@types/node": "9.6.24"
+        "@types/node": "*"
       }
     },
     "@types/jsonwebtoken": {
@@ -291,7 +291,7 @@
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
       "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
       "requires": {
-        "@types/node": "9.6.24"
+        "@types/node": "*"
       }
     },
     "@types/mime": {
@@ -314,10 +314,10 @@
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
       "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
-        "@types/caseless": "0.12.1",
-        "@types/form-data": "2.2.1",
-        "@types/node": "9.6.24",
-        "@types/tough-cookie": "2.3.3"
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
       }
     },
     "@types/serve-static": {
@@ -325,8 +325,8 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "requires": {
-        "@types/express-serve-static-core": "4.16.0",
-        "@types/mime": "2.0.0"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/sprintf-js": {
@@ -349,7 +349,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.19",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -358,13 +358,30 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
       "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
     },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
     "agent-base": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "requires": {
-        "extend": "3.0.2",
-        "semver": "5.0.3"
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
       }
     },
     "ajv": {
@@ -372,11 +389,17 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -388,7 +411,7 @@
       "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
       "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.11.1"
       }
     },
     "ampersand-collection": {
@@ -396,10 +419,10 @@
       "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-2.0.2.tgz",
       "integrity": "sha512-IjDa4HTL/tdQDDL0SGyWk4AHD02iNtUSLRWkAsJ2biPvapljW9HNgIEIdbPnnR+7Gb9BJkjesaLNjVZfAMzeuA==",
       "requires": {
-        "ampersand-class-extend": "2.0.0",
-        "ampersand-events": "2.0.2",
-        "ampersand-version": "1.0.2",
-        "lodash": "4.17.10"
+        "ampersand-class-extend": "^2.0.0",
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.11.1"
       }
     },
     "ampersand-events": {
@@ -407,8 +430,8 @@
       "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
       "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
       "requires": {
-        "ampersand-version": "1.0.2",
-        "lodash": "4.17.10"
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.6.1"
       }
     },
     "ampersand-state": {
@@ -416,11 +439,11 @@
       "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
       "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
       "requires": {
-        "ampersand-events": "2.0.2",
-        "ampersand-version": "1.0.2",
-        "array-next": "0.0.1",
-        "key-tree-store": "1.3.0",
-        "lodash": "4.17.10"
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.0",
+        "array-next": "~0.0.1",
+        "key-tree-store": "^1.3.0",
+        "lodash": "^4.12.0"
       }
     },
     "ampersand-version": {
@@ -428,8 +451,8 @@
       "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
       "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
       "requires": {
-        "find-root": "0.1.2",
-        "through2": "0.6.5"
+        "find-root": "^0.1.1",
+        "through2": "^0.6.3"
       }
     },
     "ansi-escape-sequences": {
@@ -437,9 +460,15 @@
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
       "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
       "requires": {
-        "array-back": "1.0.4",
-        "collect-all": "0.2.1"
+        "array-back": "^1.0.2",
+        "collect-all": "~0.2.1"
       }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -456,7 +485,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
@@ -471,7 +500,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
       "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.0"
       }
     },
     "array-flatten": {
@@ -479,10 +508,41 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
     "array-next": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
       "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -509,7 +569,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "asynckit": {
@@ -532,8 +592,19 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "1.5.1",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.2.5",
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-polyfill": {
@@ -541,9 +612,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -558,8 +629,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "back": {
@@ -567,7 +638,7 @@
       "resolved": "https://registry.npmjs.org/back/-/back-1.0.2.tgz",
       "integrity": "sha1-qT9ebOaXKZhNWQGiuxbjsBpNY2k=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.0"
       }
     },
     "backoff": {
@@ -575,7 +646,7 @@
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
       "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
       "requires": {
-        "precond": "0.2.3"
+        "precond": "0.2"
       }
     },
     "balanced-match": {
@@ -599,7 +670,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
@@ -607,7 +678,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "~2.0.5"
       }
     },
     "bluebird": {
@@ -621,15 +692,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       }
     },
     "boom": {
@@ -637,7 +708,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "botbuilder": {
@@ -645,23 +716,23 @@
       "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.15.0.tgz",
       "integrity": "sha512-KH5GTskHvTSozRPLdn8EQtg34zc71VUo+wXYzcoafRCkGVqqxB4AitUqow8y8ENiHgJW3oY2Pvhd8glcZiraOA==",
       "requires": {
-        "@types/async": "2.0.49",
-        "@types/express": "4.16.0",
-        "@types/form-data": "2.2.1",
-        "@types/jsonwebtoken": "7.2.8",
-        "@types/node": "9.6.24",
-        "@types/request": "2.47.1",
-        "@types/sprintf-js": "1.1.0",
-        "@types/url-join": "0.8.2",
-        "async": "1.5.2",
-        "base64url": "2.0.0",
-        "chrono-node": "1.3.5",
-        "jsonwebtoken": "7.4.3",
-        "promise": "7.3.1",
-        "request": "2.87.0",
-        "rsa-pem-from-mod-exp": "0.8.4",
-        "sprintf-js": "1.1.1",
-        "url-join": "1.1.0"
+        "@types/async": "^2.0.48",
+        "@types/express": "^4.11.1",
+        "@types/form-data": "^2.2.1",
+        "@types/jsonwebtoken": "^7.2.6",
+        "@types/node": "^9.6.1",
+        "@types/request": "^2.47.0",
+        "@types/sprintf-js": "^1.1.0",
+        "@types/url-join": "^0.8.1",
+        "async": "^1.5.2",
+        "base64url": "^2.0.0",
+        "chrono-node": "^1.1.3",
+        "jsonwebtoken": "^7.0.1",
+        "promise": "^7.1.1",
+        "request": "^2.69.0",
+        "rsa-pem-from-mod-exp": "^0.8.4",
+        "sprintf-js": "^1.0.3",
+        "url-join": "^1.1.0"
       },
       "dependencies": {
         "async": {
@@ -674,11 +745,11 @@
           "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
           "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
           "requires": {
-            "joi": "6.10.1",
-            "jws": "3.1.5",
-            "lodash.once": "4.1.1",
-            "ms": "2.0.0",
-            "xtend": "4.0.1"
+            "joi": "^6.10.1",
+            "jws": "^3.1.4",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.0.0",
+            "xtend": "^4.0.1"
           }
         }
       }
@@ -688,19 +759,19 @@
       "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.2.2.tgz",
       "integrity": "sha1-ZchNnJJ61OJnreOo21sfjOa5wyA=",
       "requires": {
-        "async": "2.6.1",
-        "back": "1.0.2",
-        "body-parser": "1.18.3",
-        "command-line-args": "2.1.6",
-        "express": "4.16.3",
-        "https-proxy-agent": "1.0.0",
-        "jfs": "0.2.6",
-        "localtunnel": "1.9.0",
-        "mustache": "2.3.0",
-        "request": "2.87.0",
-        "twilio": "2.11.1",
-        "ware": "1.3.0",
-        "ws": "1.1.5"
+        "async": "^2.0.0-rc.5",
+        "back": "^1.0.1",
+        "body-parser": "^1.14.2",
+        "command-line-args": "^2.1.6",
+        "express": "^4.13.3",
+        "https-proxy-agent": "^1.0.0",
+        "jfs": "^0.2.6",
+        "localtunnel": "^1.8.1",
+        "mustache": "^2.2.1",
+        "request": "^2.67.0",
+        "twilio": "^2.9.1",
+        "ware": "^1.3.0",
+        "ws": "^1.0.1"
       }
     },
     "botkit-sms": {
@@ -719,7 +790,7 @@
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.1"
           }
         },
         "assert-plus": {
@@ -738,15 +809,15 @@
           "integrity": "sha1-11eM9PHRHV9uqATO813Hp/9trmc=",
           "requires": {
             "bytes": "2.4.0",
-            "content-type": "1.0.4",
-            "debug": "2.2.0",
-            "depd": "1.1.2",
-            "http-errors": "1.5.1",
+            "content-type": "~1.0.2",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "http-errors": "~1.5.0",
             "iconv-lite": "0.4.13",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.2.0",
-            "raw-body": "2.1.7",
-            "type-is": "1.6.16"
+            "raw-body": "~2.1.7",
+            "type-is": "~1.6.13"
           }
         },
         "botkit": {
@@ -754,26 +825,26 @@
           "resolved": "https://registry.npmjs.org/botkit/-/botkit-0.5.4.tgz",
           "integrity": "sha1-0AZjxzdI7CFxr39ukWaJhXgftvc=",
           "requires": {
-            "async": "2.6.1",
-            "back": "1.0.2",
-            "body-parser": "1.18.3",
-            "botbuilder": "3.15.0",
-            "botkit-studio-sdk": "1.0.8",
-            "ciscospark": "0.7.93",
+            "async": "^2.1.5",
+            "back": "^1.0.1",
+            "body-parser": "^1.17.1",
+            "botbuilder": "^3.7.0",
+            "botkit-studio-sdk": "^1.0.2",
+            "ciscospark": "^0.7.69",
             "clone": "2.1.1",
-            "command-line-args": "4.0.7",
+            "command-line-args": "^4.0.2",
             "crypto": "0.0.3",
-            "express": "4.16.3",
-            "https-proxy-agent": "1.0.0",
-            "jfs": "0.2.6",
-            "localtunnel": "1.9.0",
-            "md5": "2.2.1",
-            "mustache": "2.3.0",
-            "promise": "7.3.1",
-            "request": "2.87.0",
-            "twilio": "2.11.1",
-            "ware": "1.3.0",
-            "ws": "2.3.1"
+            "express": "^4.15.2",
+            "https-proxy-agent": "^1.0.0",
+            "jfs": "^0.2.6",
+            "localtunnel": "^1.8.2",
+            "md5": "^2.2.1",
+            "mustache": "^2.3.0",
+            "promise": "^7.1.1",
+            "request": "^2.81.0",
+            "twilio": "^2.11.1",
+            "ware": "^1.3.0",
+            "ws": "^2.2.2"
           },
           "dependencies": {
             "body-parser": {
@@ -782,15 +853,15 @@
               "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
               "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
                 "iconv-lite": "0.4.23",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.2",
                 "raw-body": "2.3.3",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.16"
               }
             },
             "bytes": {
@@ -811,36 +882,36 @@
               "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
               "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
               "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.4",
+                "proxy-addr": "~2.0.3",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0",
-                "type-is": "1.6.16",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
               },
               "dependencies": {
                 "body-parser": {
@@ -849,15 +920,15 @@
                   "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
                   "requires": {
                     "bytes": "3.0.0",
-                    "content-type": "1.0.4",
+                    "content-type": "~1.0.4",
                     "debug": "2.6.9",
-                    "depd": "1.1.2",
-                    "http-errors": "1.6.3",
+                    "depd": "~1.1.1",
+                    "http-errors": "~1.6.2",
                     "iconv-lite": "0.4.19",
-                    "on-finished": "2.3.0",
+                    "on-finished": "~2.3.0",
                     "qs": "6.5.1",
                     "raw-body": "2.3.2",
-                    "type-is": "1.6.16"
+                    "type-is": "~1.6.15"
                   }
                 },
                 "iconv-lite": {
@@ -894,7 +965,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.4.0"
+                        "statuses": ">= 1.3.1 < 2"
                       }
                     },
                     "setprototypeof": {
@@ -916,10 +987,10 @@
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
               "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
               "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.5.0"
+                "statuses": ">= 1.4.0 < 2"
               }
             },
             "iconv-lite": {
@@ -927,7 +998,7 @@
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
               "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ms": {
@@ -961,13 +1032,13 @@
               "resolved": "https://registry.npmjs.org/twilio/-/twilio-2.11.1.tgz",
               "integrity": "sha1-RRCZRnMTxWs3Z5lN8tGQYvEO+MQ=",
               "requires": {
-                "deprecate": "0.1.0",
-                "jsonwebtoken": "5.4.1",
+                "deprecate": "^0.1.0",
+                "jsonwebtoken": "5.4.x",
                 "q": "0.9.7",
-                "request": "2.74.0",
+                "request": "2.74.x",
                 "scmp": "0.0.3",
-                "string.prototype.startswith": "0.2.0",
-                "underscore": "1.9.1"
+                "string.prototype.startswith": "^0.2.0",
+                "underscore": "1.x"
               },
               "dependencies": {
                 "qs": {
@@ -980,27 +1051,27 @@
                   "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
                   "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
                   "requires": {
-                    "aws-sign2": "0.6.0",
-                    "aws4": "1.7.0",
-                    "bl": "1.1.2",
-                    "caseless": "0.11.0",
-                    "combined-stream": "1.0.6",
-                    "extend": "3.0.2",
-                    "forever-agent": "0.6.1",
-                    "form-data": "1.0.1",
-                    "har-validator": "2.0.6",
-                    "hawk": "3.1.3",
-                    "http-signature": "1.1.1",
-                    "is-typedarray": "1.0.0",
-                    "isstream": "0.1.2",
-                    "json-stringify-safe": "5.0.1",
-                    "mime-types": "2.1.19",
-                    "node-uuid": "1.4.8",
-                    "oauth-sign": "0.8.2",
-                    "qs": "6.2.3",
-                    "stringstream": "0.0.6",
-                    "tough-cookie": "2.3.4",
-                    "tunnel-agent": "0.4.3"
+                    "aws-sign2": "~0.6.0",
+                    "aws4": "^1.2.1",
+                    "bl": "~1.1.2",
+                    "caseless": "~0.11.0",
+                    "combined-stream": "~1.0.5",
+                    "extend": "~3.0.0",
+                    "forever-agent": "~0.6.1",
+                    "form-data": "~1.0.0-rc4",
+                    "har-validator": "~2.0.6",
+                    "hawk": "~3.1.3",
+                    "http-signature": "~1.1.0",
+                    "is-typedarray": "~1.0.0",
+                    "isstream": "~0.1.2",
+                    "json-stringify-safe": "~5.0.1",
+                    "mime-types": "~2.1.7",
+                    "node-uuid": "~1.4.7",
+                    "oauth-sign": "~0.8.1",
+                    "qs": "~6.2.0",
+                    "stringstream": "~0.0.4",
+                    "tough-cookie": "~2.3.0",
+                    "tunnel-agent": "~0.4.1"
                   }
                 }
               }
@@ -1027,9 +1098,9 @@
           "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
           "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
           "requires": {
-            "array-back": "2.0.0",
-            "find-replace": "1.0.3",
-            "typical": "2.6.1"
+            "array-back": "^2.0.0",
+            "find-replace": "^1.0.3",
+            "typical": "^2.6.1"
           }
         },
         "debug": {
@@ -1045,32 +1116,32 @@
           "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
           "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
           "requires": {
-            "accepts": "1.3.5",
+            "accepts": "~1.3.3",
             "array-flatten": "1.1.1",
             "content-disposition": "0.5.1",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.2",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
-            "debug": "2.2.0",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "finalhandler": "0.5.0",
             "fresh": "0.3.0",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "1.1.5",
+            "proxy-addr": "~1.1.2",
             "qs": "6.2.0",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "send": "0.14.1",
-            "serve-static": "1.11.2",
-            "type-is": "1.6.16",
+            "serve-static": "~1.11.1",
+            "type-is": "~1.6.13",
             "utils-merge": "1.0.0",
-            "vary": "1.1.2"
+            "vary": "~1.1.0"
           },
           "dependencies": {
             "content-disposition": {
@@ -1088,11 +1159,11 @@
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
               "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
               "requires": {
-                "debug": "2.2.0",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "debug": "~2.2.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "statuses": "~1.3.0",
+                "unpipe": "~1.0.0"
               }
             },
             "fresh": {
@@ -1105,7 +1176,7 @@
               "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
               "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
               "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.0",
                 "ipaddr.js": "1.4.0"
               }
             },
@@ -1114,19 +1185,19 @@
               "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
               "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
               "requires": {
-                "debug": "2.2.0",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.7.0",
+                "debug": "~2.2.0",
+                "depd": "~1.1.0",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.7.0",
                 "fresh": "0.3.0",
-                "http-errors": "1.5.1",
+                "http-errors": "~1.5.0",
                 "mime": "1.3.4",
                 "ms": "0.7.1",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.3.0"
               }
             },
             "serve-static": {
@@ -1134,9 +1205,9 @@
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
               "integrity": "sha1-LPmIm9RDWjIMw2iVyapXvWYuasc=",
               "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.1",
                 "send": "0.14.2"
               },
               "dependencies": {
@@ -1150,19 +1221,19 @@
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
                   "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
                   "requires": {
-                    "debug": "2.2.0",
-                    "depd": "1.1.2",
-                    "destroy": "1.0.4",
-                    "encodeurl": "1.0.2",
-                    "escape-html": "1.0.3",
-                    "etag": "1.7.0",
+                    "debug": "~2.2.0",
+                    "depd": "~1.1.0",
+                    "destroy": "~1.0.4",
+                    "encodeurl": "~1.0.1",
+                    "escape-html": "~1.0.3",
+                    "etag": "~1.7.0",
                     "fresh": "0.3.0",
-                    "http-errors": "1.5.1",
+                    "http-errors": "~1.5.1",
                     "mime": "1.3.4",
                     "ms": "0.7.2",
-                    "on-finished": "2.3.0",
-                    "range-parser": "1.2.0",
-                    "statuses": "1.3.1"
+                    "on-finished": "~2.3.0",
+                    "range-parser": "~1.2.0",
+                    "statuses": "~1.3.1"
                   }
                 }
               }
@@ -1184,9 +1255,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "requires": {
-            "async": "2.6.1",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
           }
         },
         "har-validator": {
@@ -1194,10 +1265,10 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.16.0",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "http-errors": {
@@ -1207,7 +1278,7 @@
           "requires": {
             "inherits": "2.0.3",
             "setprototypeof": "1.0.2",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "http-signature": {
@@ -1215,9 +1286,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "iconv-lite": {
@@ -1270,14 +1341,14 @@
           "resolved": "https://registry.npmjs.org/twilio/-/twilio-2.11.0.tgz",
           "integrity": "sha1-oAPZggW9hoLcHPeuB8KD6aSfow4=",
           "requires": {
-            "deprecate": "0.1.0",
-            "jsonwebtoken": "5.4.1",
-            "jwt-simple": "0.1.0",
+            "deprecate": "^0.1.0",
+            "jsonwebtoken": "5.4.x",
+            "jwt-simple": "0.1.x",
             "q": "0.9.7",
-            "request": "2.74.0",
+            "request": "2.74.x",
             "scmp": "0.0.3",
-            "string.prototype.startswith": "0.2.0",
-            "underscore": "1.9.1"
+            "string.prototype.startswith": "^0.2.0",
+            "underscore": "1.x"
           },
           "dependencies": {
             "request": {
@@ -1285,27 +1356,27 @@
               "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
               "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.7.0",
-                "bl": "1.1.2",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "1.0.1",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.19",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.8.2",
-                "qs": "6.2.0",
-                "stringstream": "0.0.6",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.4.3"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "bl": "~1.1.2",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc4",
+                "har-validator": "~2.0.6",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.1",
+                "qs": "~6.2.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "~0.4.1"
               }
             }
           }
@@ -1320,8 +1391,8 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
           "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
           "requires": {
-            "safe-buffer": "5.0.1",
-            "ultron": "1.1.1"
+            "safe-buffer": "~5.0.1",
+            "ultron": "~1.1.0"
           },
           "dependencies": {
             "safe-buffer": {
@@ -1338,8 +1409,8 @@
       "resolved": "https://registry.npmjs.org/botkit-studio-sdk/-/botkit-studio-sdk-1.0.8.tgz",
       "integrity": "sha1-focHv7hGKBPAgVXTqIpaSQhFzPU=",
       "requires": {
-        "promise": "7.3.1",
-        "request": "2.87.0"
+        "promise": "^7.1.1",
+        "request": "^2.67.0"
       }
     },
     "bower": {
@@ -1352,7 +1423,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1381,6 +1452,21 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -1401,9 +1487,9 @@
       "resolved": "https://registry.npmjs.org/cfenv/-/cfenv-1.0.4.tgz",
       "integrity": "sha1-uXoe694lXs7YNnoPSvvC+FQ44LQ=",
       "requires": {
-        "js-yaml": "3.7.0",
-        "ports": "1.1.0",
-        "underscore": "1.8.3"
+        "js-yaml": "3.7.x",
+        "ports": "1.1.x",
+        "underscore": "1.8.x"
       },
       "dependencies": {
         "underscore": {
@@ -1418,12 +1504,18 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
     },
     "charenc": {
       "version": "0.0.2",
@@ -1435,8 +1527,14 @@
       "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.5.tgz",
       "integrity": "sha1-oklSmKMtqCvMAa2b59d++l4kQSI=",
       "requires": {
-        "moment": "2.22.2"
+        "moment": "^2.10.3"
       }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
     },
     "ciscospark": {
       "version": "0.7.93",
@@ -1448,20 +1546,35 @@
         "@ciscospark/plugin-phone": "0.7.87",
         "@ciscospark/spark-core": "0.7.87",
         "@ciscospark/storage-adapter-local-storage": "0.7.87",
-        "babel-polyfill": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "envify": "3.4.1",
-        "lodash": "4.17.10"
+        "babel-polyfill": "^6.23.0",
+        "babel-runtime": "^6.23.0",
+        "envify": "^3.4.1",
+        "lodash": "^4.17.4"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -1476,8 +1589,8 @@
       "requires": {
         "async": "2.1.2",
         "cloudant-nano": "6.7.0",
-        "debug": "3.1.0",
-        "request": "2.87.0"
+        "debug": "^3.1.0",
+        "request": "^2.81.0"
       },
       "dependencies": {
         "async": {
@@ -1485,7 +1598,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
           "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "debug": {
@@ -1503,9 +1616,9 @@
       "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
       "integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
       "requires": {
-        "browser-request": "0.3.3",
-        "debug": "3.1.0",
-        "request": "2.87.0"
+        "browser-request": "~0.3.0",
+        "debug": "^3.0.0",
+        "request": "^2.83.0"
       },
       "dependencies": {
         "debug": {
@@ -1523,11 +1636,11 @@
       "resolved": "https://registry.npmjs.org/cloudant-nano/-/cloudant-nano-6.7.0.tgz",
       "integrity": "sha1-3Hjhibi4cjX0bXg4bWCdL5v05z4=",
       "requires": {
-        "cloudant-follow": "0.17.0",
-        "debug": "3.1.0",
-        "errs": "0.3.2",
-        "request": "2.87.0",
-        "underscore": "1.9.1"
+        "cloudant-follow": "~0",
+        "debug": "^3.1.0",
+        "errs": "^0.3.2",
+        "request": "^2.81.0",
+        "underscore": "^1.8.3"
       },
       "dependencies": {
         "debug": {
@@ -1555,9 +1668,9 @@
       "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
       "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
       "requires": {
-        "stream-connect": "1.0.2",
-        "stream-via": "0.1.1",
-        "typical": "2.6.1"
+        "stream-connect": "^1.0.1",
+        "stream-via": "~0.1.0",
+        "typical": "^2.3.0"
       }
     },
     "collect-json": {
@@ -1565,9 +1678,9 @@
       "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
       "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
       "requires": {
-        "collect-all": "1.0.3",
-        "stream-connect": "1.0.2",
-        "stream-via": "1.0.4"
+        "collect-all": "^1.0.2",
+        "stream-connect": "^1.0.2",
+        "stream-via": "^1.0.3"
       },
       "dependencies": {
         "collect-all": {
@@ -1575,8 +1688,8 @@
           "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
           "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
           "requires": {
-            "stream-connect": "1.0.2",
-            "stream-via": "1.0.4"
+            "stream-connect": "^1.0.2",
+            "stream-via": "^1.0.4"
           }
         },
         "stream-via": {
@@ -1586,21 +1699,36 @@
         }
       }
     },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
+    },
     "column-layout": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
       "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
       "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-back": "1.0.4",
-        "collect-json": "1.0.8",
-        "command-line-args": "2.1.6",
-        "core-js": "2.5.7",
-        "deep-extend": "0.4.2",
-        "feature-detect-es6": "1.5.0",
-        "object-tools": "2.0.6",
-        "typical": "2.6.1",
-        "wordwrapjs": "1.2.1"
+        "ansi-escape-sequences": "^2.2.2",
+        "array-back": "^1.0.3",
+        "collect-json": "^1.0.8",
+        "command-line-args": "^2.1.6",
+        "core-js": "^2.4.0",
+        "deep-extend": "~0.4.1",
+        "feature-detect-es6": "^1.2.0",
+        "object-tools": "^2.0.6",
+        "typical": "^2.4.2",
+        "wordwrapjs": "^1.2.0"
       }
     },
     "combined-stream": {
@@ -1608,7 +1736,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-line-args": {
@@ -1616,12 +1744,12 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
       "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
       "requires": {
-        "array-back": "1.0.4",
-        "command-line-usage": "2.0.5",
-        "core-js": "2.5.7",
-        "feature-detect-es6": "1.5.0",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
+        "array-back": "^1.0.2",
+        "command-line-usage": "^2",
+        "core-js": "^2.0.1",
+        "feature-detect-es6": "^1.2.0",
+        "find-replace": "^1",
+        "typical": "^2.3.0"
       }
     },
     "command-line-usage": {
@@ -1629,12 +1757,12 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
       "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
       "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-back": "1.0.4",
-        "column-layout": "2.1.4",
-        "feature-detect-es6": "1.5.0",
-        "typical": "2.6.1",
-        "wordwrapjs": "1.2.1"
+        "ansi-escape-sequences": "^2.2.2",
+        "array-back": "^1.0.3",
+        "column-layout": "^2.1.1",
+        "feature-detect-es6": "^1.2.0",
+        "typical": "^2.4.2",
+        "wordwrapjs": "^1.2.0"
       }
     },
     "commander": {
@@ -1647,15 +1775,15 @@
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "requires": {
-        "commander": "2.16.0",
-        "detective": "4.7.1",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.23",
-        "mkdirp": "0.5.1",
-        "private": "0.1.8",
-        "q": "1.5.1",
-        "recast": "0.11.23"
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.11.17"
       },
       "dependencies": {
         "q": {
@@ -1670,14 +1798,58 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "connect": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
       "integrity": "sha1-ohNh0/QJnvdhzabcSpc7seuwo00=",
       "requires": {
-        "debug": "2.2.0",
+        "debug": "~2.2.0",
         "finalhandler": "0.4.1",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.1",
         "utils-merge": "1.0.0"
       },
       "dependencies": {
@@ -1694,10 +1866,10 @@
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
           "requires": {
-            "debug": "2.2.0",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "unpipe": "1.0.0"
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "unpipe": "~1.0.0"
           }
         },
         "ms": {
@@ -1712,6 +1884,12 @@
         }
       }
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -1722,7 +1900,7 @@
       "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-1.0.0.tgz",
       "integrity": "sha1-Ef1AxcwpimxyWjX5rPcegqtdMkM=",
       "requires": {
-        "dashify": "0.2.2"
+        "dashify": "^0.2.0"
       }
     },
     "content-type": {
@@ -1755,6 +1933,17 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -1765,7 +1954,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "crypto": {
@@ -1778,7 +1967,7 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
-        "lodash.get": "4.4.2"
+        "lodash.get": "^4.0.0"
       }
     },
     "dashdash": {
@@ -1786,7 +1975,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "dashify": {
@@ -1812,18 +2001,57 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1850,8 +2078,8 @@
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "requires": {
-        "acorn": "5.7.1",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       }
     },
     "detectrtc": {
@@ -1863,6 +2091,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.1.0.tgz",
       "integrity": "sha1-YN20V3dOF48flBXwyrsOhbCzALI="
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dom-walk": {
       "version": "0.1.1",
@@ -1885,8 +2122,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -1894,7 +2131,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -1912,8 +2149,8 @@
       "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
       "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
       "requires": {
-        "jstransform": "11.0.3",
-        "through": "2.3.8"
+        "jstransform": "^11.0.3",
+        "through": "~2.3.4"
       }
     },
     "error-ex": {
@@ -1921,13 +2158,37 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "errs": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
       "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1939,10 +2200,360 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
+      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
+      "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
+      "dev": true,
+      "requires": {
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
+      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
+      "dev": true,
+      "requires": {
+        "ignore": "^3.3.6",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.3",
+        "semver": "5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz",
+      "integrity": "sha512-18rzWn4AtbSUxFKKM7aCVcj5LXOhOKdwBino3KKWy4psxfPW0YtIbE8WNRDUdyHFL50BeLb6qFd4vpvNYyp7hw==",
+      "dev": true,
+      "requires": {
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
+      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
     "esprima-fb": {
       "version": "15001.1.0-dev-harmony-fb",
       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
       "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -1954,36 +2565,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.4",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "body-parser": {
@@ -1992,15 +2603,15 @@
           "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "http-errors": "1.6.3",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "1.6.16"
+            "type-is": "~1.6.15"
           }
         },
         "iconv-lite": {
@@ -2037,7 +2648,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.3.1 < 2"
               }
             },
             "setprototypeof": {
@@ -2059,13 +2670,35 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-2.11.0.tgz",
       "integrity": "sha512-KMZayDxj3Wr7zYuwTuDZj5hMW0nhnyJVBVCwMEVKwMdW6CkYh4vnfnUbRJYhKC0v6UuIbPerwKY0dqWmEzFjKA==",
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -2082,12 +2715,45 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "feature-detect-es6": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.5.0.tgz",
       "integrity": "sha512-DzWPIGzTnfp3/KK1d/YPfmgLqeDju9F2DQYBL35VusgSApcA7XGqVtXfR4ETOOFEzdFJ3J7zh0Gkk011TiA4uQ==",
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.4"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "file-type": {
@@ -2101,12 +2767,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -2121,8 +2787,8 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
       },
       "dependencies": {
         "test-value": {
@@ -2130,8 +2796,8 @@
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
           "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
           "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
+            "array-back": "^1.0.3",
+            "typical": "^2.6.0"
           }
         }
       }
@@ -2146,8 +2812,20 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "follow-redirects": {
@@ -2155,7 +2833,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
       "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -2173,8 +2851,14 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.4"
+        "is-callable": "^1.1.3"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2186,9 +2870,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.19"
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -2211,6 +2895,24 @@
       "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
       "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -2221,7 +2923,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -2234,7 +2936,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -2242,11 +2944,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global": {
@@ -2254,8 +2956,50 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
+      }
+    },
+    "globals": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -2273,8 +3017,17 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -2282,8 +3035,14 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "hashmap": {
       "version": "2.3.0",
@@ -2295,10 +3054,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "helmet": {
@@ -2369,10 +3128,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -2380,9 +3139,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -2390,9 +3149,9 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.2"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
       }
     },
     "iconv-lite": {
@@ -2400,7 +3159,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ienoopen": {
@@ -2408,19 +3167,115 @@
       "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.0.0.tgz",
       "integrity": "sha1-NGpCj0dKrI9QzzeE6i0PFvYr2ms="
     },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -2447,7 +3302,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -2455,12 +3310,18 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
     "is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
       "requires": {
-        "is-plain-object": "2.0.4"
+        "is-plain-object": "^2.0.4"
       }
     },
     "is-fullwidth-code-point": {
@@ -2468,7 +3329,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -2486,11 +3347,35 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-object": {
@@ -2498,13 +3383,40 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2526,6 +3438,12 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
       "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -2541,10 +3459,10 @@
       "resolved": "https://registry.npmjs.org/jfs/-/jfs-0.2.6.tgz",
       "integrity": "sha1-hRtyjuXP9EmFXPmtVU9KXhSraRI=",
       "requires": {
-        "async": "1.2.1",
-        "clone": "1.0.4",
-        "mkdirp": "0.5.1",
-        "node-uuid": "1.4.8"
+        "async": "~1.2.1",
+        "clone": "~1.0.2",
+        "mkdirp": "~0.5.1",
+        "node-uuid": "~1.4.3"
       },
       "dependencies": {
         "async": {
@@ -2559,19 +3477,25 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
-        "hoek": "2.16.3",
-        "isemail": "1.2.0",
-        "moment": "2.22.2",
-        "topo": "1.1.0"
+        "hoek": "2.x.x",
+        "isemail": "1.x.x",
+        "moment": "2.x.x",
+        "topo": "1.x.x"
       }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
       },
       "dependencies": {
         "esprima": {
@@ -2597,6 +3521,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2612,8 +3542,8 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.4.1.tgz",
       "integrity": "sha1-IFXGORlf/lYxT6alHfAkaBhqlpU=",
       "requires": {
-        "jws": "3.1.5",
-        "ms": "0.7.3"
+        "jws": "^3.0.0",
+        "ms": "^0.7.1"
       },
       "dependencies": {
         "ms": {
@@ -2639,11 +3569,20 @@
       "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
       "requires": {
-        "base62": "1.2.8",
-        "commoner": "0.10.8",
-        "esprima-fb": "15001.1.0-dev-harmony-fb",
-        "object-assign": "2.1.1",
-        "source-map": "0.4.4"
+        "base62": "^1.1.0",
+        "commoner": "^0.10.1",
+        "esprima-fb": "^15001.1.0-dev-harmony-fb",
+        "object-assign": "^2.0.0",
+        "source-map": "^0.4.2"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
       }
     },
     "jwa": {
@@ -2653,7 +3592,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
@@ -2661,8 +3600,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "1.1.6",
-        "safe-buffer": "5.1.1"
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "jwt-simple": {
@@ -2680,7 +3619,17 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -2688,11 +3637,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "localtunnel": {
@@ -2716,6 +3665,24 @@
         }
       }
     },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -2736,14 +3703,33 @@
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.5.0.tgz",
       "integrity": "sha1-r30uxiEGJEHnfVv0CKHgce+GaRw="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.6"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "media-typer": {
@@ -2781,15 +3767,21 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "requires": {
-        "mime-db": "1.35.0"
+        "mime-db": "~1.35.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -2797,7 +3789,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2828,10 +3820,22 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -2863,10 +3867,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.0.3",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "number-is-nan": {
@@ -2894,16 +3898,22 @@
       "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
       "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4="
     },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
     "object-tools": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
       "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
       "requires": {
-        "array-back": "1.0.4",
-        "collect-json": "1.0.8",
-        "object-get": "2.1.0",
-        "test-value": "1.1.0",
-        "typical": "2.6.1"
+        "array-back": "^1.0.2",
+        "collect-json": "^1.0.7",
+        "object-get": "^2.0.2",
+        "test-value": "^1.1.0",
+        "typical": "^2.4.2"
       }
     },
     "object.omit": {
@@ -2911,7 +3921,7 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
       "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
       "requires": {
-        "is-extendable": "1.0.1"
+        "is-extendable": "^1.0.0"
       }
     },
     "object.pick": {
@@ -2919,7 +3929,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "on-finished": {
@@ -2935,13 +3945,36 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
       }
     },
     "openurl": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
       "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
     },
     "options": {
       "version": "0.0.6",
@@ -2953,7 +3986,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -2961,12 +3994,36 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "parse-headers": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "0.3.3",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -2975,7 +4032,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parseurl": {
@@ -2988,13 +4045,25 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -3006,9 +4075,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "performance-now": {
@@ -3031,7 +4100,16 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
       }
     },
     "platform": {
@@ -3044,8 +4122,14 @@
       "resolved": "https://registry.npmjs.org/plotly/-/plotly-1.0.6.tgz",
       "integrity": "sha1-smcsPfiDM2Jb32hJgtDj9lIdeqo=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "~0.5.0"
       }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "ports": {
       "version": "1.1.0",
@@ -3056,6 +4140,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
       "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",
@@ -3072,12 +4162,36 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "proxy-addr": {
@@ -3085,9 +4199,15 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -3125,9 +4245,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -3135,8 +4255,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -3144,12 +4264,12 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "0.10.31",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
       }
     },
     "recast": {
@@ -3158,9 +4278,9 @@
       "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
       "requires": {
         "ast-types": "0.9.6",
-        "esprima": "3.1.3",
-        "private": "0.1.8",
-        "source-map": "0.5.7"
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
       },
       "dependencies": {
         "esprima": {
@@ -3185,31 +4305,37 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "request": {
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.19",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "uuid": {
@@ -3224,10 +4350,10 @@
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
       "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "^3.5.0",
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "request-promise-core": {
@@ -3235,7 +4361,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.13.1"
       }
     },
     "require-directory": {
@@ -3248,10 +4374,94 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -3289,18 +4499,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -3315,9 +4525,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -3331,12 +4541,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
@@ -3344,7 +4592,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "spdx-correct": {
@@ -3352,8 +4600,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -3366,8 +4614,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -3385,15 +4633,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "statuses": {
@@ -3411,7 +4659,7 @@
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.2"
       }
     },
     "stream-via": {
@@ -3434,9 +4682,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.startswith": {
@@ -3459,7 +4707,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -3467,22 +4715,110 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "test-value": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
       "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.2",
+        "typical": "^2.4.2"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
@@ -3494,8 +4830,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
         "isarray": {
@@ -3508,10 +4844,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -3521,7 +4857,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "topo": {
@@ -3529,7 +4865,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
       "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "tough-cookie": {
@@ -3537,7 +4873,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim": {
@@ -3550,7 +4886,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -3564,13 +4900,13 @@
       "resolved": "https://registry.npmjs.org/twilio/-/twilio-2.11.1.tgz",
       "integrity": "sha1-RRCZRnMTxWs3Z5lN8tGQYvEO+MQ=",
       "requires": {
-        "deprecate": "0.1.0",
-        "jsonwebtoken": "5.4.1",
+        "deprecate": "^0.1.0",
+        "jsonwebtoken": "5.4.x",
         "q": "0.9.7",
-        "request": "2.74.0",
+        "request": "2.74.x",
         "scmp": "0.0.3",
-        "string.prototype.startswith": "0.2.0",
-        "underscore": "1.9.1"
+        "string.prototype.startswith": "^0.2.0",
+        "underscore": "1.x"
       },
       "dependencies": {
         "assert-plus": {
@@ -3593,9 +4929,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "requires": {
-            "async": "2.6.1",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.19"
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
           }
         },
         "har-validator": {
@@ -3603,10 +4939,10 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.16.0",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "http-signature": {
@@ -3614,9 +4950,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "qs": {
@@ -3629,27 +4965,27 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.7.0",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.1",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.19",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.3",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc4",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1"
           }
         },
         "tunnel-agent": {
@@ -3659,21 +4995,36 @@
         }
       }
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.19"
+        "mime-types": "~2.1.18"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "typical": {
@@ -3731,8 +5082,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -3750,9 +5101,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "ware": {
@@ -3760,7 +5111,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "0.1.5"
+        "wrap-fn": "^0.1.0"
       }
     },
     "watson-developer-cloud": {
@@ -3768,24 +5119,24 @@
       "resolved": "https://registry.npmjs.org/watson-developer-cloud/-/watson-developer-cloud-3.7.1.tgz",
       "integrity": "sha512-m5M/Dge+9tOaFtuIA2bOSIjLCJq3GGMfBYRo633aHVTKvSUzT68EGwStHKqr4e243TPK1Lv8l/zSbOP364FlxA==",
       "requires": {
-        "@types/csv-stringify": "1.4.2",
-        "@types/extend": "3.0.0",
-        "@types/file-type": "5.2.1",
-        "@types/is-stream": "1.1.0",
-        "@types/node": "10.3.6",
-        "@types/request": "2.47.1",
-        "async": "2.6.1",
-        "buffer-from": "1.1.1",
-        "csv-stringify": "1.0.4",
-        "extend": "3.0.2",
-        "file-type": "7.7.1",
-        "isstream": "0.1.2",
-        "mime-types": "2.1.19",
-        "object.omit": "3.0.0",
-        "object.pick": "1.3.0",
-        "request": "2.87.0",
-        "vcap_services": "0.3.4",
-        "websocket": "1.0.26"
+        "@types/csv-stringify": "~1.4.2",
+        "@types/extend": "~3.0.0",
+        "@types/file-type": "~5.2.1",
+        "@types/is-stream": "~1.1.0",
+        "@types/node": "~10.3.5",
+        "@types/request": "~2.47.1",
+        "async": "~2.6.1",
+        "buffer-from": "~1.1.0",
+        "csv-stringify": "~1.0.2",
+        "extend": "~3.0.1",
+        "file-type": "^7.7.1",
+        "isstream": "~0.1.2",
+        "mime-types": "~2.1.18",
+        "object.omit": "~3.0.0",
+        "object.pick": "~1.3.0",
+        "request": "~2.87.0",
+        "vcap_services": "~0.3.4",
+        "websocket": "~1.0.26"
       },
       "dependencies": {
         "@types/node": {
@@ -3810,7 +5161,7 @@
       "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-3.4.3.tgz",
       "integrity": "sha1-tjYGLu6abvFYrNDYUBtnhDS1bxY=",
       "requires": {
-        "sdp": "1.5.4"
+        "sdp": "^1.5.0"
       }
     },
     "websocket": {
@@ -3818,10 +5169,19 @@
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
       "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
       "requires": {
-        "debug": "2.6.9",
-        "nan": "2.10.0",
-        "typedarray-to-buffer": "3.1.5",
-        "yaeti": "0.0.6"
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -3829,13 +5189,19 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wordwrapjs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
       "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "typical": "^2.5.0"
       }
     },
     "wrap-ansi": {
@@ -3843,8 +5209,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrap-fn": {
@@ -3867,13 +5233,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
     "ws": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "x-xss-protection": {
@@ -3901,24 +5276,30 @@
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
     "yargs": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^4.2.0"
       }
     },
     "yargs-parser": {
@@ -3926,7 +5307,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Demonstration of a chat-bot for managing a portfolio",
   "scripts": {
     "start": "node server.js",
-    "test-casper-runner": "NODE_ENV=test node casper-runner.js"
+    "test-casper-runner": "NODE_ENV=test node casper-runner.js",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "author": "Tom Eck",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -54,5 +54,14 @@
     "uuid": "^2.0.2",
     "object.pick": "^1.1.2",
     "xmlhttprequest": "^1.4.0"
+  },
+  "devDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-config-standard": "^11.0.0-beta.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-standard": "^3.0.1"
   }
 }

--- a/public/js/payload.js
+++ b/public/js/payload.js
@@ -44,8 +44,7 @@ var PayloadPanel = (function() {
       />/g, '&gt;');
     convert = convert
       .replace(
-        // eslint-disable-next-line
-        /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
+        /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
         function(match) {
           var cls = 'number';
           if (/^"/.test(match)) {

--- a/public/js/payload.js
+++ b/public/js/payload.js
@@ -44,6 +44,7 @@ var PayloadPanel = (function() {
       />/g, '&gt;');
     convert = convert
       .replace(
+        // eslint-disable-next-line
         /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
         function(match) {
           var cls = 'number';


### PR DESCRIPTION
There aren't any tests, so don't run `npm test`, we can at least run `npm run lint`. The lint job brings in a few new dev dependencies, like eslint, but it at least makes sure we have code that is valid.

I had to ignore the one error I was getting on my laptop:

```
smartinelli-mac personal-wealth-portfolio-mgt-bot $ npm run lint

> portfolio-chat@0.0.1 lint /Users/stevemar/workspace/personal-wealth-portfolio-mgt-bot
> eslint .
```

Closes #30 